### PR TITLE
added event for served downloads (GDEV-1459)

### DIFF
--- a/ghga_event_schemas/__init__.py
+++ b/ghga_event_schemas/__init__.py
@@ -15,4 +15,4 @@
 
 """A package that collects schemas used for events exchanges between GHGA service."""
 
-__version__ = "0.6.1"
+__version__ = "0.7.0"

--- a/ghga_event_schemas/pydantic_.py
+++ b/ghga_event_schemas/pydantic_.py
@@ -234,6 +234,24 @@ class FileStagedForDownload(NonStagedFileRequested):
         title = "file_staged_for_download"
 
 
+class FileDownloadServed(NonStagedFileRequested):
+    """This event type is triggered when a the content of a file was served
+    for download. This event might be useful for auditing."""
+
+    context: str = Field(
+        ...,
+        description=(
+            "The context in which the download was served (e.g. the ID of the data"
+            + " access request)."
+        ),
+    )
+
+    class Config:
+        """Additional Model Config."""
+
+        title = "file_download_served"
+
+
 # Lists event schemas (values) by event types (key):
 schema_registry: dict[str, type[BaseModel]] = {
     "metadata_submission_upserted": MetadataSubmissionUpserted,
@@ -244,4 +262,5 @@ schema_registry: dict[str, type[BaseModel]] = {
     "file_registered_for_download": FileRegisteredForDownload,
     "non_staged_file_requested": NonStagedFileRequested,
     "file_staged_for_download": FileStagedForDownload,
+    "file_download_served": FileDownloadServed,
 }


### PR DESCRIPTION
```
This event type is triggered when a the content of a file was served for download. This event might be useful for auditing.

Bumps version to 0.7.0

Co-authored-by: Moritz Hahn <75744178+MoritzHahn1337@users.noreply.github.com>
```