### PR TITLE
Update with object & bucket id

### DIFF
--- a/ghga_event_schemas/pydantic_.py
+++ b/ghga_event_schemas/pydantic_.py
@@ -132,10 +132,10 @@ class FileUploadReceived(UploadDateModel):
         ...,
         description="The public ID of the file as present in the metadata catalog.",
     )
-    object_id: str = Field(
+    source_object_id: str = Field(
         ..., description="The ID of the file in the specific S3 bucket."
     )
-    bucket_id: str = Field(
+    source_bucket_id: str = Field(
         ..., description="The ID/name of the S3 bucket used to store the file."
     )
     submitter_public_key: str = Field(
@@ -168,10 +168,10 @@ class FileUploadValidationSuccess(UploadDateModel):
     file_id: str = Field(
         ..., description="The public ID of the file as present in the metadata catalog."
     )
-    object_id: str = Field(
+    source_object_id: str = Field(
         ..., description="The ID of the file in the specific S3 bucket."
     )
-    bucket_id: str = Field(
+    source_bucket_id: str = Field(
         ..., description="The ID/name of the S3 bucket used to store the file."
     )
     decrypted_size: int = Field(
@@ -234,10 +234,10 @@ class FileUploadValidationFailure(UploadDateModel):
     file_id: str = Field(
         ..., description="The public ID of the file as present in the metadata catalog."
     )
-    object_id: str = Field(
+    source_object_id: str = Field(
         ..., description="The ID of the file in the specific S3 bucket."
     )
-    bucket_id: str = Field(
+    source_bucket_id: str = Field(
         ...,
         description="The ID/name of the S3 bucket used to store the file.",
     )
@@ -298,7 +298,7 @@ class NonStagedFileRequested(BaseModel):
     file_id: str = Field(
         ..., description="The public ID of the file as present in the metadata catalog."
     )
-    object_id: str = Field(
+    target_object_id: str = Field(
         ..., description="The ID of the file in the specific S3 bucket."
     )
     target_bucket_id: str = Field(

--- a/ghga_event_schemas/pydantic_.py
+++ b/ghga_event_schemas/pydantic_.py
@@ -234,6 +234,13 @@ class FileUploadValidationFailure(UploadDateModel):
     file_id: str = Field(
         ..., description="The public ID of the file as present in the metadata catalog."
     )
+    object_id: str = Field(
+        ..., description="The ID of the file in the specific S3 bucket."
+    )
+    bucket_id: str = Field(
+        ...,
+        description="The ID/name of the S3 bucket used to store the file.",
+    )
     reason: str = Field(
         ...,
         description="The reason why the validation failed.",
@@ -294,8 +301,9 @@ class NonStagedFileRequested(BaseModel):
     object_id: str = Field(
         ..., description="The ID of the file in the specific S3 bucket."
     )
-    bucket_id: str = Field(
-        ..., description="The ID/name of the S3 bucket used to store the file."
+    target_bucket_id: str = Field(
+        ...,
+        description="The ID/name of the S3 bucket in which the object was expected.",
     )
     decrypted_sha256: str = Field(
         ...,

--- a/ghga_event_schemas/pydantic_.py
+++ b/ghga_event_schemas/pydantic_.py
@@ -125,12 +125,18 @@ class MetadataSubmissionUpserted(BaseModel):
 
 class FileUploadReceived(UploadDateModel):
     """
-    This event is triggered when an new file upload was received.
+    This event is triggered when a new file upload is received.
     """
 
     file_id: str = Field(
         ...,
         description="The public ID of the file as present in the metadata catalog.",
+    )
+    object_id: str = Field(
+        ..., description="The ID of the file in the specific S3 bucket."
+    )
+    bucket_id: str = Field(
+        ..., description="The ID/name of the S3 bucket used to store the file."
     )
     submitter_public_key: str = Field(
         ...,
@@ -156,11 +162,17 @@ class FileUploadReceived(UploadDateModel):
 
 class FileUploadValidationSuccess(UploadDateModel):
     """
-    This event is triggered when an uploaded file was successfully validated.
+    This event is triggered when an uploaded file is successfully validated.
     """
 
     file_id: str = Field(
         ..., description="The public ID of the file as present in the metadata catalog."
+    )
+    object_id: str = Field(
+        ..., description="The ID of the file in the specific S3 bucket."
+    )
+    bucket_id: str = Field(
+        ..., description="The ID/name of the S3 bucket used to store the file."
     )
     decrypted_size: int = Field(
         ...,
@@ -272,12 +284,18 @@ class FileRegisteredForDownload(UploadDateModel):
 
 class NonStagedFileRequested(BaseModel):
     """
-    This event type is triggered when a user requested to download a file that is not
-    yet present in the outbox and need to be staged.
+    This event type is triggered when a user requests to download a file that is not
+    yet present in the outbox and needs to be staged.
     """
 
     file_id: str = Field(
         ..., description="The public ID of the file as present in the metadata catalog."
+    )
+    object_id: str = Field(
+        ..., description="The ID of the file in the specific S3 bucket."
+    )
+    bucket_id: str = Field(
+        ..., description="The ID/name of the S3 bucket used to store the file."
     )
     decrypted_sha256: str = Field(
         ...,


### PR DESCRIPTION
Updated FileUploadReceived, FileUploadValidationSuccess, NonStagedFileRequested with "object_id" and "bucket_id". The original ticket mentioned FileInternallyRegistered, but that inherits from FileUploadValidationSuccess already. 