### PR TITLE
Rename object_id and bucket_id fields (GSI-223)

### DIFF
--- a/.devcontainer/dev_install
+++ b/.devcontainer/dev_install
@@ -10,7 +10,7 @@ python -m pip install --upgrade pip
 pip install -e .[all]
 
 # install or upgrade dependencies for development and testing
-pip install --upgrade -r requirements-dev.txt
+pip install -r requirements-dev.txt
 
 # install pre-commit hooks to git
 pre-commit install

--- a/ghga_event_schemas/__init__.py
+++ b/ghga_event_schemas/__init__.py
@@ -15,4 +15,4 @@
 
 """A package that collects schemas used for events exchanges between GHGA service."""
 
-__version__ = "0.13.0"
+__version__ = "0.13.1"

--- a/ghga_event_schemas/pydantic_.py
+++ b/ghga_event_schemas/pydantic_.py
@@ -252,67 +252,12 @@ class FileUploadValidationFailure(UploadDateModel):
         title = "file_upload_validation_failure"
 
 
-class FileInternallyRegistered(BaseModel):
+class FileInternallyRegistered(FileUploadValidationSuccess):
     """
     This event is triggered when an newly uploaded file is internally registered.
     """
 
-    # currently identical to the FileUploadValidationSuccess event model, except for the
-    # object and bucket ID fields
-    file_id: str = Field(
-        ..., description="The public ID of the file as present in the metadata catalog."
-    )
-    object_id: str = Field(
-        ..., description="The ID of the file in the specific S3 bucket."
-    )
-    bucket_id: str = Field(
-        ..., description="The ID/name of the S3 bucket used to store the file."
-    )
-    decrypted_size: int = Field(
-        ...,
-        description="The size of the entire decrypted file content in bytes.",
-    )
-    decryption_secret_id: str = Field(
-        ...,
-        description=(
-            "The ID of the symmetic file encryption/decryption secret."
-            + " Please note, this is not the secret itself."
-        ),
-    )
-    content_offset: int = Field(
-        ...,
-        description=(
-            "The offset in bytes at which the encrypted content starts (excluding the"
-            + " crypt4GH envelope)."
-        ),
-    )
-    encrypted_part_size: int = Field(
-        ...,
-        description=(
-            "The size of the file parts of the encrypted content (excluding the"
-            + " crypt4gh envelope) as used for the encrypted_parts_md5 and the"
-            + " encrypted_parts_sha256 in bytes. The same part size is recommended for"
-            + " moving that content."
-        ),
-    )
-    encrypted_parts_md5: list[str] = Field(
-        ...,
-        description=(
-            "MD5 checksums of file parts of the encrypted content (excluding the"
-            + " crypt4gh envelope)."
-        ),
-    )
-    encrypted_parts_sha256: list[str] = Field(
-        ...,
-        description=(
-            "SHA-256 checksums of file parts of the encrypted content (excluding the"
-            + " crypt4gh envelope)."
-        ),
-    )
-    decrypted_sha256: str = Field(
-        ...,
-        description="The SHA-256 checksum of the entire decrypted file content.",
-    )
+    # currently identical to the FileUploadValidationSuccess event model
 
     class Config:
         """Additional Model Config."""

--- a/ghga_event_schemas/pydantic_.py
+++ b/ghga_event_schemas/pydantic_.py
@@ -252,12 +252,67 @@ class FileUploadValidationFailure(UploadDateModel):
         title = "file_upload_validation_failure"
 
 
-class FileInternallyRegistered(FileUploadValidationSuccess):
+class FileInternallyRegistered(BaseModel):
     """
     This event is triggered when an newly uploaded file is internally registered.
     """
 
-    # currently identical to the FileUploadValidationSuccess event model.
+    # currently identical to the FileUploadValidationSuccess event model, except for the
+    # object and bucket ID fields
+    file_id: str = Field(
+        ..., description="The public ID of the file as present in the metadata catalog."
+    )
+    target_object_id: str = Field(
+        ..., description="The ID of the file in the specific S3 bucket."
+    )
+    target_bucket_id: str = Field(
+        ..., description="The ID/name of the S3 bucket used to store the file."
+    )
+    decrypted_size: int = Field(
+        ...,
+        description="The size of the entire decrypted file content in bytes.",
+    )
+    decryption_secret_id: str = Field(
+        ...,
+        description=(
+            "The ID of the symmetic file encryption/decryption secret."
+            + " Please note, this is not the secret itself."
+        ),
+    )
+    content_offset: int = Field(
+        ...,
+        description=(
+            "The offset in bytes at which the encrypted content starts (excluding the"
+            + " crypt4GH envelope)."
+        ),
+    )
+    encrypted_part_size: int = Field(
+        ...,
+        description=(
+            "The size of the file parts of the encrypted content (excluding the"
+            + " crypt4gh envelope) as used for the encrypted_parts_md5 and the"
+            + " encrypted_parts_sha256 in bytes. The same part size is recommended for"
+            + " moving that content."
+        ),
+    )
+    encrypted_parts_md5: list[str] = Field(
+        ...,
+        description=(
+            "MD5 checksums of file parts of the encrypted content (excluding the"
+            + " crypt4gh envelope)."
+        ),
+    )
+    encrypted_parts_sha256: list[str] = Field(
+        ...,
+        description=(
+            "SHA-256 checksums of file parts of the encrypted content (excluding the"
+            + " crypt4gh envelope)."
+        ),
+    )
+    decrypted_sha256: str = Field(
+        ...,
+        description="The SHA-256 checksum of the entire decrypted file content.",
+    )
 
     class Config:
         """Additional Model Config."""

--- a/ghga_event_schemas/pydantic_.py
+++ b/ghga_event_schemas/pydantic_.py
@@ -132,10 +132,10 @@ class FileUploadReceived(UploadDateModel):
         ...,
         description="The public ID of the file as present in the metadata catalog.",
     )
-    source_object_id: str = Field(
+    object_id: str = Field(
         ..., description="The ID of the file in the specific S3 bucket."
     )
-    source_bucket_id: str = Field(
+    bucket_id: str = Field(
         ..., description="The ID/name of the S3 bucket used to store the file."
     )
     submitter_public_key: str = Field(
@@ -168,10 +168,10 @@ class FileUploadValidationSuccess(UploadDateModel):
     file_id: str = Field(
         ..., description="The public ID of the file as present in the metadata catalog."
     )
-    source_object_id: str = Field(
+    object_id: str = Field(
         ..., description="The ID of the file in the specific S3 bucket."
     )
-    source_bucket_id: str = Field(
+    bucket_id: str = Field(
         ..., description="The ID/name of the S3 bucket used to store the file."
     )
     decrypted_size: int = Field(
@@ -234,10 +234,10 @@ class FileUploadValidationFailure(UploadDateModel):
     file_id: str = Field(
         ..., description="The public ID of the file as present in the metadata catalog."
     )
-    source_object_id: str = Field(
+    object_id: str = Field(
         ..., description="The ID of the file in the specific S3 bucket."
     )
-    source_bucket_id: str = Field(
+    bucket_id: str = Field(
         ...,
         description="The ID/name of the S3 bucket used to store the file.",
     )
@@ -262,10 +262,10 @@ class FileInternallyRegistered(BaseModel):
     file_id: str = Field(
         ..., description="The public ID of the file as present in the metadata catalog."
     )
-    target_object_id: str = Field(
+    object_id: str = Field(
         ..., description="The ID of the file in the specific S3 bucket."
     )
-    target_bucket_id: str = Field(
+    bucket_id: str = Field(
         ..., description="The ID/name of the S3 bucket used to store the file."
     )
     decrypted_size: int = Field(


### PR DESCRIPTION
The NonStagedFileRequested event will use target_object_id and target_bucket_id, as will the two events derived from it, FileStagedForDownload and FileDownloadServed.

All other relevant events will use object_id and bucket_id, since they don't directly request any action for the given values.