### PR TITLE
Fix pypi_publish and outdated readme

### DIFF
--- a/.github/workflows/pypi_publish.yaml
+++ b/.github/workflows/pypi_publish.yaml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Verify Package Version vs Tag Version
         run: |
-          PKG_VER="$(python setup.py -V)"
+          PKG_VER="$(grep -oP 'version = "\K[^"]+' pyproject.toml)"
           TAG_VER="${GITHUB_REF##*/}"
           echo "Package version is $PKG_VER" >&2
           echo "Tag version is $TAG_VER" >&2

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Moreover, inside the devcontainer, there if following convenience commands avail
 (please type it in the integrated terminal of vscode):
 `dev_install` - installs the package with all development dependencies and installs pre-commit
 (please run that if you are starting the devcontainer for the first time
-or if you added any python dependencies to the [`./setup.cfg`](./setup.cfg))
+or if you added any python dependencies to the [`./pyproject.toml`](./pyproject.toml))
 
 If you prefer not to use vscode, you could get a similar setup (without the editor specific features)
 by running the following commands:


### PR DESCRIPTION
Quick fix for the `pypi_publish.yaml` workflow that didn't get updated for the `pyproject.toml` overhaul. 
Also updated an old reference to `setup.py` in the readme.