### PR TITLE
New events for Access Requests and IVA actions (GSI-668)

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ghga_event_schemas"
-version = "3.0.1"
+version = "3.1.0"
 description = "GHGA Event Schemas: A package that collects schemas used for events exchanged between GHGA service."
 dependencies = [
     "jsonschema>=4.17.3,<5.0.0",

--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ We recommend using the provided Docker container.
 
 A pre-build version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/ghga-event-schemas):
 ```bash
-docker pull ghga/ghga-event-schemas:3.0.1
+docker pull ghga/ghga-event-schemas:3.1.0
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/ghga-event-schemas:3.0.1 .
+docker build -t ghga/ghga-event-schemas:3.1.0 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -31,7 +31,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/ghga-event-schemas:3.0.1 --help
+docker run -p 8080:8080 ghga/ghga-event-schemas:3.1.0 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "ghga_event_schemas"
-version = "3.0.1"
+version = "3.1.0"
 description = "GHGA Event Schemas: A package that collects schemas used for events exchanged between GHGA service."
 dependencies = [
     "jsonschema>=4.17.3,<5.0.0",

--- a/src/ghga_event_schemas/pydantic_.py
+++ b/src/ghga_event_schemas/pydantic_.py
@@ -392,6 +392,18 @@ class FileDeletionSuccess(FileDeletionRequested):
     model_config = ConfigDict(title="file_deletion_success")
 
 
+class UserID(BaseModel):
+    """Generic event payload to relay a user ID."""
+
+    user_id: str
+
+
+class AccessRequestDetails(UserID):
+    """Event used to convey the user ID and dataset ID of an access request."""
+
+    dataset_id: str
+
+
 # Lists event schemas (values) by event types (key):
 schema_registry: dict[str, type[BaseModel]] = {
     "metadata_dataset_deleted": MetadataDatasetID,
@@ -408,4 +420,6 @@ schema_registry: dict[str, type[BaseModel]] = {
     "notification": Notification,
     "searchable_resource_deleted": SearchableResourceInfo,
     "searchable_resource_upserted": SearchableResource,
+    "user_id": UserID,
+    "access_request_details": AccessRequestDetails,
 }


### PR DESCRIPTION
Adds the UserID schema containing a single field of the same name. IVA actions can use this schema along with event type to broadcast notification sources as needed. 

The AccessRequestDetails schema is added too. It inherits from UserID and adds `dataset_id`. These two fields + event type are enough. 