### PR TITLE
Add missing event type config parameters (GSI-1436)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
         args: [--check]
         pass_filenames: false
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer

--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ghga_event_schemas"
-version = "4.1.0"
+version = "5.0.0"
 description = "GHGA Event Schemas: A package that collects schemas used for events exchanged between GHGA service."
 dependencies = [
     "jsonschema>=4.21.1,<5.0.0",

--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ We recommend using the provided Docker container.
 
 A pre-build version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/ghga-event-schemas):
 ```bash
-docker pull ghga/ghga-event-schemas:4.1.0
+docker pull ghga/ghga-event-schemas:5.0.0
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/ghga-event-schemas:4.1.0 .
+docker build -t ghga/ghga-event-schemas:5.0.0 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -31,7 +31,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/ghga-event-schemas:4.1.0 --help
+docker run -p 8080:8080 ghga/ghga-event-schemas:5.0.0 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "ghga_event_schemas"
-version = "4.1.0"
+version = "5.0.0"
 description = "GHGA Event Schemas: A package that collects schemas used for events exchanged between GHGA service."
 dependencies = [
     "jsonschema>=4.21.1,<5.0.0",

--- a/src/ghga_event_schemas/configs/stateless.py
+++ b/src/ghga_event_schemas/configs/stateless.py
@@ -68,7 +68,7 @@ class FileUploadReceivedEventsConfig(BaseSettings):
         description="The name of the topic used for FileUploadReceived events.",
         examples=["received-file-uploads"],
     )
-    file_upload_received_event_type: str = Field(
+    file_upload_received_type: str = Field(
         default=...,
         description="The name of the type used for FileUploadReceived events.",
         examples=["file_upload_received"],
@@ -99,12 +99,12 @@ class FileStagingRequestedEventsConfig(BaseSettings):
             "Name of the topic used for events indicating that a download was requested"
             + " for a file that is not yet available in the outbox."
         ),
-        examples=["file-downloads", "file-stage-requests"],
+        examples=["file-staging-requests"],
     )
-    files_to_stage_event_type: str = Field(
+    files_to_stage_type: str = Field(
         default=...,
         description="The type used for non-staged file request events",
-        examples=["non_staged_file_requested"],
+        examples=["file_staging_requested"],
     )
 
 
@@ -154,7 +154,7 @@ class FileDeletionRequestEventsConfig(BaseSettings):
         description="The name of the topic to receive events informing about files to delete.",
         examples=["file-deletion-requests"],
     )
-    file_deletion_request_event_type: str = Field(
+    file_deletion_request_type: str = Field(
         default=...,
         description="The type used for events indicating that a request to delete"
         + " a file has been received.",
@@ -192,7 +192,7 @@ class _FileInterrogationsConfig(BaseSettings):
 class FileInterrogationSuccessEventsConfig(_FileInterrogationsConfig):
     """For events conveying that a file interrogation was successful"""
 
-    interrogation_success_event_type: str = Field(
+    interrogation_success_type: str = Field(
         default=...,
         description=(
             "The type used for events informing about successful file validations."

--- a/src/ghga_event_schemas/configs/stateless.py
+++ b/src/ghga_event_schemas/configs/stateless.py
@@ -68,6 +68,11 @@ class FileUploadReceivedEventsConfig(BaseSettings):
         description="The name of the topic used for FileUploadReceived events.",
         examples=["received-file-uploads"],
     )
+    file_upload_received_event_type: str = Field(
+        default=...,
+        description="The name of the type used for FileUploadReceived events.",
+        examples=["file_upload_received"],
+    )
 
 
 class NotificationEventsConfig(BaseSettings):
@@ -95,6 +100,11 @@ class FileStagingRequestedEventsConfig(BaseSettings):
             + " for a file that is not yet available in the outbox."
         ),
         examples=["file-downloads", "file-stage-requests"],
+    )
+    files_to_stage_event_type: str = Field(
+        default=...,
+        description="The type used for non-staged file request events",
+        examples=["non_staged_file_requested"],
     )
 
 
@@ -144,6 +154,12 @@ class FileDeletionRequestEventsConfig(BaseSettings):
         description="The name of the topic to receive events informing about files to delete.",
         examples=["file-deletion-requests"],
     )
+    file_deletion_request_event_type: str = Field(
+        default=...,
+        description="The type used for events indicating that a request to delete"
+        + " a file has been received.",
+        examples=["file_deletion_requested"],
+    )
 
 
 class FileDeletedEventsConfig(BaseSettings):
@@ -175,6 +191,14 @@ class _FileInterrogationsConfig(BaseSettings):
 
 class FileInterrogationSuccessEventsConfig(_FileInterrogationsConfig):
     """For events conveying that a file interrogation was successful"""
+
+    interrogation_success_event_type: str = Field(
+        default=...,
+        description=(
+            "The type used for events informing about successful file validations."
+        ),
+        examples=["file_interrogation_success"],
+    )
 
 
 class FileInterrogationFailureEventsConfig(_FileInterrogationsConfig):


### PR DESCRIPTION
This PR adds the `_event_type` fields to the stateless event config classes that lacked them.  
The reason they were missing is because some services were publishing the events using the outbox pattern, which doesn't use a configured event type (instead, `hexkit` hard-codes the value).  
Now that we've got the `PersistentKafkaPublisher` in `hexkit`, we can go back to using regular event types.