### PR TITLE
Add remaining fields to AccessRequestDetails model

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ghga_event_schemas"
-version = "7.0.0"
+version = "8.0.0"
 description = "GHGA Event Schemas: A package that collects schemas used for events exchanged between GHGA service."
 dependencies = [
     "jsonschema>=4.23.0,<5.0.0",

--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ We recommend using the provided Docker container.
 
 A pre-built version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/ghga-event-schemas):
 ```bash
-docker pull ghga/ghga-event-schemas:7.0.0
+docker pull ghga/ghga-event-schemas:8.0.0
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/ghga-event-schemas:7.0.0 .
+docker build -t ghga/ghga-event-schemas:8.0.0 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -31,7 +31,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/ghga-event-schemas:7.0.0 --help
+docker run -p 8080:8080 ghga/ghga-event-schemas:8.0.0 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "ghga_event_schemas"
-version = "7.0.0"
+version = "8.0.0"
 description = "GHGA Event Schemas: A package that collects schemas used for events exchanged between GHGA service."
 dependencies = [
     "jsonschema>=4.23.0,<5.0.0",

--- a/src/ghga_event_schemas/pydantic_.py
+++ b/src/ghga_event_schemas/pydantic_.py
@@ -438,6 +438,17 @@ class AccessRequestDetails(UserID):
         ...,
         description="The alias of the Data Access Committee responsible for the dataset",
     )
+    ticket_id: str = Field(
+        ..., description="The ID of the ticket associated with the access request"
+    )
+    internal_note: str | None = Field(
+        default=None,
+        description="A note about the access request only visible to Data Stewards",
+    )
+    note_to_requester: str | None = Field(
+        default=None,
+        description="A note about the access request that is visible to the requester",
+    )
     access_starts: UTCDatetime = Field(
         ...,
         description="The beginning of the access request's validity period as a UTC datetime",


### PR DESCRIPTION
Adds the following fields to the `AccessRequestDetails` model:
- `ticket_id`
- `internal_note`
- `note_to_requester`