### PR TITLE
Add DAC email in access request as well

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,12 +1,12 @@
 [project]
 name = "ghga_event_schemas"
-version = "9.0.0"
+version = "9.1.0"
 description = "GHGA Event Schemas: A package that collects schemas used for events exchanged between GHGA service."
 dependencies = [
     "jsonschema>=4.23.0,<5.0.0",
     "pydantic[email]>=2,<3",
-    "pydantic_settings >=2, <3",
-    "ghga-service-commons>=1.2.0",
+    "pydantic_settings>=2,<3",
+    "ghga-service-commons>=4.1.0",
 ]
 
 [project.urls]

--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ We recommend using the provided Docker container.
 
 A pre-built version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/ghga-event-schemas):
 ```bash
-docker pull ghga/ghga-event-schemas:9.0.0
+docker pull ghga/ghga-event-schemas:9.1.0
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/ghga-event-schemas:9.0.0 .
+docker build -t ghga/ghga-event-schemas:9.1.0 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -31,7 +31,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/ghga-event-schemas:9.0.0 --help
+docker run -p 8080:8080 ghga/ghga-event-schemas:9.1.0 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,13 +21,13 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "ghga_event_schemas"
-version = "9.0.0"
+version = "9.1.0"
 description = "GHGA Event Schemas: A package that collects schemas used for events exchanged between GHGA service."
 dependencies = [
     "jsonschema>=4.23.0,<5.0.0",
     "pydantic[email]>=2,<3",
-    "pydantic_settings >=2, <3",
-    "ghga-service-commons>=1.2.0",
+    "pydantic_settings>=2,<3",
+    "ghga-service-commons>=4.1.0",
 ]
 
 [project.license]

--- a/src/ghga_event_schemas/pydantic_.py
+++ b/src/ghga_event_schemas/pydantic_.py
@@ -85,7 +85,7 @@ class MetadataDatasetOverview(MetadataDatasetID):
     )
     description: str | None = Field(..., description="The description of the dataset.")
     dac_alias: str = Field(..., description="The alias of the Data Access Committee.")
-    dac_email: str = Field(
+    dac_email: EmailStr = Field(
         ..., description="The email address of the Data Access Committee."
     )
     files: list[MetadataDatasetFile] = Field(
@@ -458,6 +458,9 @@ class AccessRequestDetails(UserID):
     dac_alias: str = Field(
         ...,
         description="The alias of the Data Access Committee responsible for the dataset",
+    )
+    dac_email: EmailStr = Field(
+        ..., description="The email address of the Data Access Committee."
     )
     ticket_id: str | None = Field(
         default=None,


### PR DESCRIPTION
The DAC email wa still missing in the Access Request. It should be validated as email. When imported from metadata, it may need to be converted (`[at]` and `[dot]` replaced with `@` and `.`).