### PR TITLE
Support for Publishing Entire Artifacts (GSI-1696)

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ghga_event_schemas"
-version = "9.1.0"
+version = "9.2.0"
 description = "GHGA Event Schemas: A package that collects schemas used for events exchanged between GHGA service."
 dependencies = [
     "jsonschema>=4.23.0,<5.0.0",

--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ We recommend using the provided Docker container.
 
 A pre-built version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/ghga-event-schemas):
 ```bash
-docker pull ghga/ghga-event-schemas:9.1.0
+docker pull ghga/ghga-event-schemas:9.2.0
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/ghga-event-schemas:9.1.0 .
+docker build -t ghga/ghga-event-schemas:9.2.0 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -31,7 +31,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/ghga-event-schemas:9.1.0 --help
+docker run -p 8080:8080 ghga/ghga-event-schemas:9.2.0 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/lock/requirements-dev-template.in
+++ b/lock/requirements-dev-template.in
@@ -20,7 +20,7 @@ httpx>=0.28
 pytest-httpx>=0.35
 
 urllib3>=2.4
-requests>=2.32
+requests>=2.32.4
 
 casefy>=1.1
 jsonschema2md>=1.5

--- a/lock/requirements-dev.txt
+++ b/lock/requirements-dev.txt
@@ -543,9 +543,9 @@ referencing==0.36.2 \
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.32.3 \
-    --hash=sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760 \
-    --hash=sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6
+requests==2.32.4 \
+    --hash=sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c \
+    --hash=sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422
     # via
     #   -r lock/requirements-dev-template.in
     #   docker

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "ghga_event_schemas"
-version = "9.1.0"
+version = "9.2.0"
 description = "GHGA Event Schemas: A package that collects schemas used for events exchanged between GHGA service."
 dependencies = [
     "jsonschema>=4.23.0,<5.0.0",

--- a/src/ghga_event_schemas/configs/stateful.py
+++ b/src/ghga_event_schemas/configs/stateful.py
@@ -92,3 +92,16 @@ class AccessRequestEventsConfig(BaseSettings):
         description="Name of the event topic containing access request events",
         examples=["access-requests"],
     )
+
+
+class ArtifactEventsConfig(BaseSettings):
+    """Config for events communicating changes in metadata artifacts.
+
+    The event types are hardcoded in `metldata` to be "upserted" and "deleted".
+    """
+
+    artifact_topic: str = Field(
+        default=...,
+        description="Name of the event topic containing artifact events",
+        examples=["artifacts"],
+    )

--- a/src/ghga_event_schemas/pydantic_.py
+++ b/src/ghga_event_schemas/pydantic_.py
@@ -74,10 +74,10 @@ class SearchableResource(SearchableResourceInfo):
 
 
 class ArtifactTag(BaseModel):
-    """A model representing a tag for an artifact (artifact name and submission ID)."""
+    """A model representing a tag for an artifact (artifact name and study accession)."""
 
-    submission_id: str = Field(
-        ..., description="The ID of the submission this artifact belongs to."
+    study_accession: str = Field(
+        ..., description="The ID of the study this artifact pertains to."
     )
     artifact_name: str = Field(
         ..., description="The name of the artifact, e.g. 'added_accessions'."

--- a/src/ghga_event_schemas/pydantic_.py
+++ b/src/ghga_event_schemas/pydantic_.py
@@ -73,6 +73,25 @@ class SearchableResource(SearchableResourceInfo):
     )
 
 
+class ArtifactTag(BaseModel):
+    """A model representing a tag for an artifact (artifact name and submission ID)."""
+
+    submission_id: str = Field(
+        ..., description="The ID of the submission this artifact belongs to."
+    )
+    artifact_name: str = Field(
+        ..., description="The name of the artifact, e.g. 'added_accessions'."
+    )
+
+
+class Artifact(ArtifactTag):
+    """A model representing an artifact."""
+
+    content: dict[str, Any] = Field(
+        ..., description="The metadata content of the artifact."
+    )
+
+
 class MetadataDatasetOverview(MetadataDatasetID):
     """
     Overview of files contained in a dataset.


### PR DESCRIPTION
This PR adds models and config so metldata can publish artifacts as a whole, identified by the submission ID.